### PR TITLE
Enable 2021

### DIFF
--- a/lib/tasks/ensure_full_seed.rake
+++ b/lib/tasks/ensure_full_seed.rake
@@ -1,0 +1,25 @@
+namespace :db do
+  desc "Ensure the full seed data has been loaded"
+  task :ensure_full_seed => :environment do
+    enterprise = Enterprises::Enterprise.where(owner_organization_name: 'OpenHBX').first
+    if enterprise
+      ResourceRegistry::AppSettings[:options].each do |option_hash|
+        if option_hash[:key] == :benefit_years
+          option = Options::Option.new(option_hash)
+      
+          option.child_options.each do |setting|
+            existing_benefit_year = Enterprises::BenefitYear.where(
+              calendar_year: setting.key.to_s.to_i,
+              enterprise_id: enterprise.id
+            ).first
+            unless existing_benefit_year
+              enterprise.benefit_years.create({ expected_contribution: setting.default, calendar_year: setting.key.to_s.to_i, description: setting.description })
+            end
+          end
+        end
+      end
+    else
+      Rake::Task["db:seed"].invoke
+    end
+  end
+end

--- a/system/config/enterprise.yml
+++ b/system/config/enterprise.yml
@@ -18,3 +18,7 @@ namespaces:
             default: 0.0978
             type: :float
             description: For 2020 the factor is 0.0978 and should not be changed.
+          - key: :2021
+            default: 0.0978
+            type: :float
+            description: For 2021 the factor is 0.0978 and should not be changed.


### PR DESCRIPTION
Create plan years automatically based on settings file.

If you want a new year, add it to the settings and run the "rake db:ensure_full_seed" task to build it.

If you have a blank/first-time DB, running "rake db:seed" will build it automatically.